### PR TITLE
Logit adjustment modification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ cython_debug/
 # logit_adjustment
 
 logit_adjustment/log
+logit_adjustment/data/cifar*.tfrecord
 
 # extreme classification
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Specifically it contains:
     * one for Figures 2, 3 and 4 - binary problem
     * one for Figures 5 and 6 - multiclass problem
 * modified code for CIFAR-10 experiments
-    * (TODO) a clone of the code for ["Long-tail learning via logit adjustment" (Menon et. al)](https://arxiv.org/abs/2007.07314)
+    * a clone of the code for ["Long-tail learning via logit adjustment" (Menon et. al)](https://arxiv.org/abs/2007.07314)
     * a clone of the code for ["Learning Imbalanced Datasets with Label-Distribution-Aware Margin Loss" (Cao et. al)](https://arxiv.org/abs/1906.07413)
-* (TODO) notebooks for additional plots
+* notebook for additional plots
 * (TODO) a pdf copy of the dissertation
 
 (TODO) Add set up instructions (poetry/setup.py)

--- a/logit_adjustment/README.md
+++ b/logit_adjustment/README.md
@@ -8,84 +8,45 @@ ICLR 2021.
 
 ## Running the code
 
-#### 1. Setting up the Python environment
-The code has been tested with Python 3.7.2. The necessary libraries can be
-installed using pip with the following command:
+#### Dependencies
 
-```
-# from dissertation-extreme-classification/
-pip install -r logit_adjustment/requirements.txt
-```
+See the main README.md (in the parent directory).
 
 
-#### 2. Testing the code
-The code may be tested on a dummy dataset using:
+#### Dataset
 
-```
-# from dissertation-extreme-classification/
-python -m logit_adjustment.main --dataset=test --mode=baseline --train_batch_size=2 --test_batch_size=2
-```
+Imbalanced CIFAR. The original data can be downloaded via the links:
+* [cifar10-lt_train.tfrecord](http://storage.googleapis.com/gresearch/logit_adjustment/cifar10-lt_train.tfrecord)
+* [cifar10_test.tfrecord](http://storage.googleapis.com/gresearch/logit_adjustment/cifar10_test.tfrecord)
+* [cifar100-lt_train.tfrecord](http://storage.googleapis.com/gresearch/logit_adjustment/cifar100-lt_train.tfrecord)
+* [cifar100_test.tfrecord](http://storage.googleapis.com/gresearch/logit_adjustment/cifar100_test.tfrecord)
 
-This should complete quickly without any errors.
+or with the ```download_tfrecord``` function in ```utils.py``` (which can be run through the notebook).
 
 
-#### 3. Downloading CIFAR-10/100 long-tail datasets
-Download the CIFAR-10/100 long-tail datasets using the links provided below and
-put the `.tfrecord` files in the `logit_adjustment/data/` directory. The train
-datasets were created with the EXP-100 profile as detailed in the paper, the
+#### Training (and evaluation)
+
+We need the `.tfrecord` files in the `data` directory for training and evaluation. The train datasets were created with the EXP-100 profile as detailed in the paper, the
 test datasets are the same as the standard CIFAR-10/100 test datasets.
 
-Links: [cifar10-lt_train.tfrecord](http://storage.googleapis.com/gresearch/logit_adjustment/cifar10-lt_train.tfrecord),
-[cifar10_test.tfrecord](http://storage.googleapis.com/gresearch/logit_adjustment/cifar10_test.tfrecord),
-[cifar100-lt_train.tfrecord](http://storage.googleapis.com/gresearch/logit_adjustment/cifar100-lt_train.tfrecord),
-[cifar100_test.tfrecord](http://storage.googleapis.com/gresearch/logit_adjustment/cifar100_test.tfrecord).
+See the notebook ```logit_adjustment.ipynb``` for commands to train on the imbalanced CIFAR 10 with different losses.
 
+Below is an example:
 
-#### 4. Running the code on CIFAR-10/100 long-tail datasets
+To train the ERM baseline on long-tailed imbalance with ratio of 100
 
-You can now run the code on the CIFAR-10 long-tail dataset using the commands
-below:
+```python main.py --dataset=cifar10-lt --mode=baseline```
 
-```
-# from dissertation-extreme-classification/
+This will train the models and evaluate them on the imbalanced train and balanced test sets. 
 
-# To produce baseline (ERM) results:
-python -m logit_adjustment.main --dataset=cifar10-lt --mode=baseline
-
-# To produce posthoc logit-adjustment results:
-python -m logit_adjustment.main --dataset=cifar10-lt --mode=posthoc
-
-# To produce logit-adjustment loss results:
-python -m logit_adjustment.main --dataset=cifar10-lt --mode=loss
-```
-
-Replace `cifar10-lt` above with `cifar100-lt` to obtain results for the
-CIFAR-100 long-tail dataset. On each invocation, the code will print log
-messages to the console. Final test accuracy will also be visible in these
-log messages. You can monitor the training progress using Tensorboard:
-
-```
-# from dissertation-extreme-classification/
-tensorboard --logdir=./logit_adjustment/log
-```
-
-Note: You may want to delete the above Tensorboard log directory before each
-new invocation of the training.
+It will log metrics like train and test and accuracy to the log directory with Tensorboard. You can view the results directly via Tensorboard, or see below.
 
 ## Results
 
-Example (balanced) test accuracies obtained by running this code on a GPU device
-is shown below for different datasets.
+See the Read the results section in the notebook.
 
-<center>
+Here we reproduce Table 1 and Figure 1.
 
-|             | Baseline (ERM) | Post-hoc logit adjustment | Logit adjustment loss |
-|:------------|:--------------:|:-------------------------:|:-----------------:|
-| CIFAR-10 LT |       0.7136   |          0.7732           |       0.7789      |
-| CIFAR-100 LT|       0.3987   |          0.4407           |       0.4406      |
+Table 1: the final epoch accuracies on the test set. We display these in a pandas DataFrame.
 
-</center>
-
-<br/>
-Please contact `sadeep {at} google.com` if you encounter any issues with this
-code.
+Figure 1: Altair bar charts to show the effective class probabilities with different values of $\beta$.

--- a/logit_adjustment/logit_adjustment.ipynb
+++ b/logit_adjustment/logit_adjustment.ipynb
@@ -13,11 +13,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import altair as alt\n",
     "\n",
-    "from utils import download_tfrecord"
+    "from utils import download_tfrecord\n",
+    "from tensorflow import make_ndarray\n",
+    "from tensorboard.backend.event_processing.event_accumulator import EventAccumulator\n",
+    "from tensorboard.backend.event_processing.tag_types import TENSORS"
    ]
   },
   {
@@ -264,6 +268,81 @@
     "    color=alt.Color(\"β:N\", sort=βs),\n",
     "    column=alt.Column(\"class_num:O\", title=\"Classes (ranked by frequency)\"),\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Table 1\n",
+    "\n",
+    "We get the final test accuracy for each of the approaches (baseline ERM, posthoc update and logit adjusted loss)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_tensorboard_data(log_dir: str) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Returns the logs from Tensorboard SummaryWriter in blob storage as a pandas DataFrame.\n",
+    "\n",
+    "    Args:\n",
+    "        log_dir (str): the path to the Tensorboard logs\n",
+    "        print_scalars (bool): whether or not to print the list of scalars from the EventAccumulator. By default False (so doesn't print).\n",
+    "    \"\"\"\n",
+    "\n",
+    "    event_acc = EventAccumulator(log_dir, size_guidance={TENSORS: 0})\n",
+    "    event_acc.Reload()\n",
+    "\n",
+    "    data = []\n",
+    "    tensors = event_acc.Tags()[\"tensors\"]\n",
+    "\n",
+    "    for tag in tensors:\n",
+    "        events = event_acc.Tensors(tag)\n",
+    "        steps = [event.step for event in events]\n",
+    "        tensor_protos = [make_ndarray(event.tensor_proto).item() for event in events]\n",
+    "        for step, tensor_proto in list(zip(steps, tensor_protos)):\n",
+    "            data.append(\n",
+    "                {\n",
+    "                    \"experiment\": exp_name,\n",
+    "                    \"metric\": tag,\n",
+    "                    \"step\": step,\n",
+    "                    \"value\": tensor_proto,\n",
+    "                }\n",
+    "            )\n",
+    "\n",
+    "    df = pd.DataFrame(data)\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_exp_names = sorted(os.listdir(\"./log\"))  # the folder names\n",
+    "exp_names = [\n",
+    "    _exp_name.replace(\"_\", \" \") for _exp_name in _exp_names\n",
+    "]  # remove underscore for space\n",
+    "\n",
+    "df = pd.DataFrame()\n",
+    "\n",
+    "for _exp_name, exp_name in list(zip(_exp_names, exp_names)):\n",
+    "    df = pd.concat([df, load_tensorboard_data(\"./log/\" + _exp_name + \"/test\")])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "final_accuracy_df = df[df.step == 19200].reset_index().drop([\"index\", \"step\"], axis=1)\n",
+    "final_accuracy_df"
    ]
   }
  ],

--- a/logit_adjustment/logit_adjustment.ipynb
+++ b/logit_adjustment/logit_adjustment.ipynb
@@ -1,0 +1,291 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import altair as alt\n",
+    "\n",
+    "from utils import download_tfrecord"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tensorboard"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Launch a TensorBoard Session in VS Code or...\n",
+    "\n",
+    "Run the below (you may have to run the second command twice)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext tensorboard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%tensorboard --logdir=log"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or use\n",
+    "\n",
+    "```\n",
+    "!tensorboard --logdir log\n",
+    "```\n",
+    "if the above doesn't work"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Datasets\n",
+    "\n",
+    "Run the below cells to download the CIFAR-10 datasets (or the CIFAR-100 ones)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "download_tfrecord(\"test10\", \"train10\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Training (and evaluation)\n",
+    "\n",
+    "Use ```main.py``` to train on the imbalanced version of CIFAR 10. This is to get the results in Table 1.\n",
+    "\n",
+    "Call it with the following flags/parameters:\n",
+    "\n",
+    "* ```dataset```: ```cifar10-lt``` (for CIFAR 10)\n",
+    "* ```mode```: ```baseline```, ```posthoc``` or ```loss```\n",
+    "    * whether to use baseline (vanilla) ERM\n",
+    "    * or posthoc modification of logits\n",
+    "    * or adjusted loss function\n",
+    "\n",
+    "The results can be found in Tensorboard: ..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Experiments and Results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Vanilla ERM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python main.py --dataset=cifar10-lt --mode=baseline --tb_log_dir=log/ERM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Posthoc update"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python main.py --dataset=cifar10-lt --mode=posthoc --tb_log_dir=log/Additive_update"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Logit adjusted loss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python main.py --dataset=cifar10-lt --mode=loss --tb_log_dir=log/LA"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Read the results\n",
+    "\n",
+    "* For Figure 1 and Table 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Figure 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the class probabilities\n",
+    "\n",
+    "# Define the file path\n",
+    "file_path = \"./data/cifar10-lt_base_probs.txt\"\n",
+    "\n",
+    "# Initialize a list to store the numbers\n",
+    "class_prob = []\n",
+    "\n",
+    "# Open the file and read it line by line\n",
+    "with open(file_path, \"r\") as file:\n",
+    "    for line in file:\n",
+    "        # Remove leading/trailing whitespace and convert the line to a float\n",
+    "        number = float(line.strip())\n",
+    "        class_prob.append(number)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# the number of samples in the training data. possible values for β\n",
+    "\n",
+    "N = 10000\n",
+    "βs = [1, 0.999, 0.99, 0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# calculate effective class frequency with formula in terms of β and empirical class frequency\n",
+    "\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"class_num\": list(range(1, 10 + 1)) * len(βs),\n",
+    "        \"class_prob\": class_prob * len(βs),\n",
+    "        \"β\": sum([[β] * 10 for β in βs], start=[]),\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "df[\"effective_class_frequency\"] = (1 - df[\"β\"] ** (N * df[\"class_prob\"])) / (\n",
+    "    1 - df[\"β\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# normalise effective class frequency to get effective class probability\n",
+    "\n",
+    "df[\"effective_class_frequency\"] = df[\"effective_class_frequency\"] / df.groupby(\"β\")[\n",
+    "    \"effective_class_frequency\"\n",
+    "].transform(\"sum\")\n",
+    "\n",
+    "# when β = 1, use empirical class probability\n",
+    "\n",
+    "df[\"effective_class_frequency\"] = np.where(\n",
+    "    df[\"effective_class_frequency\"].isna(),\n",
+    "    df[\"class_prob\"],\n",
+    "    df[\"effective_class_frequency\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot effective class probability for each class number for each β\n",
+    "\n",
+    "alt.Chart(data=df).mark_bar().encode(\n",
+    "    x=alt.X(\"β:N\", title=None, axis=alt.Axis(ticks=False, labels=False), sort=βs),\n",
+    "    y=alt.Y(\"effective_class_frequency\", title=\"Smoothed class probability\"),\n",
+    "    color=alt.Color(\"β:N\", sort=βs),\n",
+    "    column=alt.Column(\"class_num:O\", title=\"Classes (ranked by frequency)\"),\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/logit_adjustment/main.py
+++ b/logit_adjustment/main.py
@@ -25,139 +25,148 @@ import os
 
 from absl import app
 from absl import flags
-from logit_adjustment import models
-from logit_adjustment import utils
+import models
+import utils
 import numpy as np
 import tensorflow as tf
 
 FLAGS = flags.FLAGS
 
-flags.DEFINE_string('dataset', 'cifar10-lt', 'Dataset to use.')
-flags.DEFINE_string('data_home', 'logit_adjustment/data',
-                    'Directory where data files are stored.')
-flags.DEFINE_integer('train_batch_size', 128, 'Train batch size.')
-flags.DEFINE_integer('test_batch_size', 100, 'Test batch size.')
-flags.DEFINE_enum('mode', 'posthoc', ['baseline', 'posthoc', 'loss'],
-                  'Logit-adjustment mode. See paper for details.')
-flags.DEFINE_float('tau', 1.0, 'Tau parameter for logit adjustment.')
-flags.DEFINE_string('tb_log_dir', 'logit_adjustment/log',
-                    'Path to write Tensorboard summaries.')
+flags.DEFINE_string("dataset", "cifar10-lt", "Dataset to use.")
+flags.DEFINE_string("data_home", "data", "Directory where data files are stored.")
+flags.DEFINE_integer("train_batch_size", 128, "Train batch size.")
+flags.DEFINE_integer("test_batch_size", 100, "Test batch size.")
+flags.DEFINE_enum(
+    "mode",
+    "posthoc",
+    ["baseline", "posthoc", "loss"],
+    "Logit-adjustment mode. See paper for details.",
+)
+flags.DEFINE_float("tau", 1.0, "Tau parameter for logit adjustment.")
+flags.DEFINE_string("tb_log_dir", "log", "Path to write Tensorboard summaries.")
 
 
 def main(_):
+    # Prepare the datasets.
+    dataset = utils.dataset_mappings()[FLAGS.dataset]
+    batches_per_epoch = int(dataset.num_train / FLAGS.train_batch_size)
+    train_dataset = utils.create_tf_dataset(
+        dataset, FLAGS.data_home, FLAGS.train_batch_size, True
+    )
+    test_dataset = utils.create_tf_dataset(
+        dataset, FLAGS.data_home, FLAGS.test_batch_size, False
+    )
 
-  # Prepare the datasets.
-  dataset = utils.dataset_mappings()[FLAGS.dataset]
-  batches_per_epoch = int(dataset.num_train / FLAGS.train_batch_size)
-  train_dataset = utils.create_tf_dataset(dataset, FLAGS.data_home,
-                                          FLAGS.train_batch_size, True)
-  test_dataset = utils.create_tf_dataset(dataset, FLAGS.data_home,
-                                         FLAGS.test_batch_size, False)
+    # Model to be trained.
+    model = models.cifar_resnet32(dataset.num_classes)
 
-  # Model to be trained.
-  model = models.cifar_resnet32(dataset.num_classes)
+    # Read the base probabilities to use for logit adjustment.
+    base_probs_path = os.path.join(FLAGS.data_home, f"{FLAGS.dataset}_base_probs.txt")
+    try:
+        with tf.io.gfile.GFile(base_probs_path, mode="r") as fin:
+            base_probs = np.loadtxt(fin)
+    except tf.errors.NotFoundError:
+        if FLAGS.mode in ["posthoc", "loss"]:
+            raise app.UsageError(
+                f"{base_probs_path} must exist when `mode` is {FLAGS.mode}."
+            )
+        else:
+            base_probs = None
 
-  # Read the base probabilities to use for logit adjustment.
-  base_probs_path = os.path.join(FLAGS.data_home,
-                                 f'{FLAGS.dataset}_base_probs.txt')
-  try:
-    with tf.io.gfile.GFile(base_probs_path, mode='r') as fin:
-      base_probs = np.loadtxt(fin)
-  except tf.errors.NotFoundError:
-    if FLAGS.mode in ['posthoc', 'loss']:
-      raise app.UsageError(
-          f'{base_probs_path} must exist when `mode` is {FLAGS.mode}.')
-    else:
-      base_probs = None
+    # Build the loss function.
+    loss_fn = utils.build_loss_fn(FLAGS.mode == "loss", base_probs, FLAGS.tau)
 
-  # Build the loss function.
-  loss_fn = utils.build_loss_fn(FLAGS.mode == 'loss', base_probs, FLAGS.tau)
-
-  # Prepare the metrics, the optimizer, etc.
-  train_acc_metric = tf.keras.metrics.SparseCategoricalAccuracy()
-  test_acc_metric = tf.keras.metrics.SparseCategoricalAccuracy()
-  posthoc_adjusting = FLAGS.mode == 'posthoc'
-  if posthoc_adjusting:
-    test_adj_acc_metric = tf.keras.metrics.SparseCategoricalAccuracy()
-
-  learning_rate = utils.LearningRateSchedule(
-      schedule=dataset.lr_schedule,
-      steps_per_epoch=batches_per_epoch,
-      base_learning_rate=0.1,
-  )
-
-  optimizer = tf.keras.optimizers.SGD(
-      learning_rate,
-      momentum=0.9,
-      nesterov=True,
-  )
-
-  # Prepare Tensorboard summary writers.
-  train_summary_writer = tf.summary.create_file_writer(
-      os.path.join(FLAGS.tb_log_dir, 'train'))
-  test_summary_writer = tf.summary.create_file_writer(
-      os.path.join(FLAGS.tb_log_dir, 'test'))
-
-  # Train for num_epochs iterations over the train set.
-  for epoch in range(dataset.num_epochs):
-
-    # Iterate over the train dataset.
-    for step, (x, y) in enumerate(train_dataset):
-      with tf.GradientTape() as tape:
-        logits = model(x, training=True)
-        loss_value = loss_fn(y, logits)
-        loss_value = loss_value + tf.reduce_sum(model.losses)
-
-      grads = tape.gradient(loss_value, model.trainable_weights)
-      optimizer.apply_gradients(zip(grads, model.trainable_weights))
-
-      train_acc_metric.update_state(y, logits)
-
-      # Log every 1000 batches.
-      if step % 1000 == 0:
-        print(f'Training loss (for one batch) at step {step}: {loss_value:.4f}')
-        with train_summary_writer.as_default():
-          tf.summary.scalar(
-              'batch loss', loss_value, step=epoch * batches_per_epoch + step)
-
-    # Display train metrics at the end of each epoch.
-    train_acc = train_acc_metric.result()
-    train_acc_metric.reset_states()
-    print(f'Training accuracy over epoch: {train_acc:.4f}')
-    with train_summary_writer.as_default():
-      tf.summary.scalar(
-          'accuracy', train_acc, step=(epoch + 1) * batches_per_epoch)
-
-    # Run a test loop at the end of each epoch.
-    for x, y in test_dataset:
-      logits = model(x, training=False)
-      test_acc_metric.update_state(y, logits)
-
-      if posthoc_adjusting:
-        # Posthoc logit-adjustment.
-        adjusted_logits = logits - tf.math.log(
-            tf.cast(base_probs**FLAGS.tau + 1e-12, dtype=tf.float32))
-        test_adj_acc_metric.update_state(y, adjusted_logits)
-
-    # Display test metrics.
-    test_acc = test_acc_metric.result()
-    test_acc_metric.reset_states()
-    print(f'Test accuracy: {test_acc:.4f}')
-    with test_summary_writer.as_default():
-      tf.summary.scalar(
-          'accuracy', test_acc, step=(epoch + 1) * batches_per_epoch)
-
+    # Prepare the metrics, the optimizer, etc.
+    train_acc_metric = tf.keras.metrics.SparseCategoricalAccuracy()
+    test_acc_metric = tf.keras.metrics.SparseCategoricalAccuracy()
+    posthoc_adjusting = FLAGS.mode == "posthoc"
     if posthoc_adjusting:
-      test_adj_acc = test_adj_acc_metric.result()
-      test_adj_acc_metric.reset_states()
-      print(f'Logit-adjusted test accuracy: {test_adj_acc:.4f}')
+        test_adj_acc_metric = tf.keras.metrics.SparseCategoricalAccuracy()
 
-      with test_summary_writer.as_default():
-        tf.summary.scalar(
-            'logit-adjusted accuracy',
-            test_adj_acc,
-            step=(epoch + 1) * batches_per_epoch)
+    learning_rate = utils.LearningRateSchedule(
+        schedule=dataset.lr_schedule,
+        steps_per_epoch=batches_per_epoch,
+        base_learning_rate=0.1,
+    )
+
+    optimizer = tf.keras.optimizers.SGD(
+        learning_rate,
+        momentum=0.9,
+        nesterov=True,
+    )
+
+    # Prepare Tensorboard summary writers.
+    train_summary_writer = tf.summary.create_file_writer(
+        os.path.join(FLAGS.tb_log_dir, "train")
+    )
+    test_summary_writer = tf.summary.create_file_writer(
+        os.path.join(FLAGS.tb_log_dir, "test")
+    )
+
+    # Train for num_epochs iterations over the train set.
+    for epoch in range(dataset.num_epochs):
+        # Iterate over the train dataset.
+        for step, (x, y) in enumerate(train_dataset):
+            with tf.GradientTape() as tape:
+                logits = model(x, training=True)
+                loss_value = loss_fn(y, logits)
+                loss_value = loss_value + tf.reduce_sum(model.losses)
+
+            grads = tape.gradient(loss_value, model.trainable_weights)
+            optimizer.apply_gradients(zip(grads, model.trainable_weights))
+
+            train_acc_metric.update_state(y, logits)
+
+            # Log every 1000 batches.
+            if step % 1000 == 0:
+                print(f"Training loss (for one batch) at step {step}: {loss_value:.4f}")
+                with train_summary_writer.as_default():
+                    tf.summary.scalar(
+                        "batch loss", loss_value, step=epoch * batches_per_epoch + step
+                    )
+
+        # Display train metrics at the end of each epoch.
+        train_acc = train_acc_metric.result()
+        train_acc_metric.reset_states()
+        print(f"Training accuracy over epoch: {train_acc:.4f}")
+        with train_summary_writer.as_default():
+            tf.summary.scalar(
+                "accuracy", train_acc, step=(epoch + 1) * batches_per_epoch
+            )
+
+        # Run a test loop at the end of each epoch.
+        for x, y in test_dataset:
+            logits = model(x, training=False)
+            test_acc_metric.update_state(y, logits)
+
+            if posthoc_adjusting:
+                # Posthoc logit-adjustment.
+                adjusted_logits = logits - tf.math.log(
+                    tf.cast(base_probs**FLAGS.tau + 1e-12, dtype=tf.float32)
+                )
+                test_adj_acc_metric.update_state(y, adjusted_logits)
+
+        # Display test metrics.
+        test_acc = test_acc_metric.result()
+        test_acc_metric.reset_states()
+        print(f"Test accuracy: {test_acc:.4f}")
+        with test_summary_writer.as_default():
+            tf.summary.scalar(
+                "accuracy", test_acc, step=(epoch + 1) * batches_per_epoch
+            )
+
+        if posthoc_adjusting:
+            test_adj_acc = test_adj_acc_metric.result()
+            test_adj_acc_metric.reset_states()
+            print(f"Logit-adjusted test accuracy: {test_adj_acc:.4f}")
+
+            with test_summary_writer.as_default():
+                tf.summary.scalar(
+                    "logit-adjusted accuracy",
+                    test_adj_acc,
+                    step=(epoch + 1) * batches_per_epoch,
+                )
 
 
-if __name__ == '__main__':
-  app.run(main)
+if __name__ == "__main__":
+    app.run(main)

--- a/logit_adjustment/requirements.txt
+++ b/logit_adjustment/requirements.txt
@@ -1,2 +1,0 @@
-numpy>=1.16.0
-tensorflow>=2.4.0


### PR DESCRIPTION
Added functionality to download the CIFAR 10 and 100 tfrecords

Added a notebook that can

- download the datasets
- train in the three modes (baseline, posthoc and loss), and log the results to Tensorboard
- read the Tensorboard logs and show the final test set accuracies
- plot the effective class probabilities for different values of β

Updated main and logit_adjustment README

Modified the main module:
- remove 'logit_adjustment' from imports
- change default log and data directory